### PR TITLE
Removed Deprecated and unsupported code.

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -114,7 +114,7 @@ function onIceCandidate(event) {
 }
 
 function onAddStream(event) {
-    remoteVideo.src = URL.createObjectURL(event.stream);
+    remoteVideo.srcObject  = event.stream;
     remoteStream = event.stream;
     if (remoteStream.getAudioTracks().length > 0) {
         addAudioEvent('Remote user is sending Audio');
@@ -144,7 +144,7 @@ function setLocalAndAnswer(sessionDescription) {
 //utility functions
 function addLocalStream(stream) {
     localStream = stream;
-    localVideo.src = URL.createObjectURL(stream);
+    localVideo.srcObject = stream
 
     if (stream.getAudioTracks().length > 0) {
         btnMute.style = "display: block";


### PR DESCRIPTION
Per https://developers.google.com/web/updates/2018/10/chrome-71-deps-rems#remove_urlcreateobjecturl_from_mediastream
Use of 'URL.createObjectURL' is now fully deprecated and has been removed from the MediaStream interface. Is now superseded by HTMLMediaElement.srcObject.

See https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject for more details.